### PR TITLE
Add edit id for commands

### DIFF
--- a/src/main/kotlin/com/github/vacxe/googleplaycli/Commands.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/Commands.kt
@@ -4,29 +4,38 @@ import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.*
 import com.github.vacxe.googleplaycli.actions.model.*
 import com.github.vacxe.googleplaycli.core.BaseCommand
+import com.github.vacxe.googleplaycli.core.EditCommand
 import java.io.File
 import java.nio.file.Path
 
 object Commands {
     object Apks {
-        class Upload : BaseCommand(name = "upload", actionDescription = "") {
+        class List : EditCommand(name = "list", actionDescription = "Lists all current APKs for the specified package and edit") {
+            override fun run(api: PlayStoreApi) = api.apksList(EditModel(packageName, editId))
+        }
+
+        class Upload : EditCommand(name = "upload", actionDescription = "") {
             private val apk: File by option("--apk", "-a", help = "Apk file path").file().required()
-            override fun run(api: PlayStoreApi) = api.apksUpload(ApksUploadModel(packageName, apk))
+            override fun run(api: PlayStoreApi) = api.apksUpload(ApksUploadModel(packageName, editId, apk))
         }
     }
 
     object Bundles {
-        class Upload : BaseCommand(name = "upload", actionDescription = "Uploads a new Android App Bundle to this edit") {
+        class List : EditCommand(name = "list", actionDescription = "List of all Android App Bundle") {
+            override fun run(api: PlayStoreApi) = api.bundlesList(EditModel(packageName, editId))
+        }
+
+        class Upload : EditCommand(name = "upload", actionDescription = "Uploads a new Android App Bundle to this edit") {
             private val bundle: File by option("--bundle", "-b", help = "Bundle file path").file().required()
             private val ackBundleInstallationWarning: Boolean by option("--ack-bundle-installation-warning", "-a", help = "Must be set to true if the bundle installation may trigger a warning on user devices (for example, if installation size may be over a threshold, typically 100 MB).")
                     .flag(default = false)
 
-            override fun run(api: PlayStoreApi) = api.bundlesUpload(BundlesUploadModel(packageName, bundle, ackBundleInstallationWarning))
+            override fun run(api: PlayStoreApi) = api.bundlesUpload(BundlesUploadModel(packageName, editId, bundle, ackBundleInstallationWarning))
         }
     }
 
     object Deobfuscationfiles {
-        class Upload : BaseCommand(name = "upload", actionDescription = "Uploads the deobfuscation file of the specified APK. If a deobfuscation file already exists, it will be replaced") {
+        class Upload : EditCommand(name = "upload", actionDescription = "Uploads the deobfuscation file of the specified APK. If a deobfuscation file already exists, it will be replaced") {
             private val deobfuscation: File by option("--deobfuscation", "-d", help = "Deobfuscation file path")
                     .file()
                     .required()
@@ -38,206 +47,240 @@ object Commands {
                     .choice("proguard")
                     .default("proguard")
 
-            override fun run(api: PlayStoreApi) = api.deobfuscationFilesUpload(DeobfuscationfilesUploadModel(packageName, apkVersionCode, deobfuscation, deobfuscationFileType))
+            override fun run(api: PlayStoreApi) = api.deobfuscationFilesUpload(DeobfuscationfilesUploadModel(packageName, editId, apkVersionCode, deobfuscation, deobfuscationFileType))
         }
     }
 
     object Details {
-        class Patch : BaseCommand(name = "patch", actionDescription = "Updates app details for this edit") {
-            private val contactEmail: String? by option("--contact-email", "-e", help = "The user-visible support email for this app")
-            private val contactPhone: String? by option("--contact-phone", help = "The user-visible support telephone number for this app")
-            private val contactWebsite: String? by option("--contact-website", "-w", help = "The user-visible website for this app")
-            private val defaultLanguage: String? by option("--default-language", "-l", help = "Default language code, in BCP 47 format (eg \"en-US\").")
-
-            override fun run(api: PlayStoreApi) = api.detailsPatch(DetailsPatchModel(packageName, contactEmail, contactPhone, contactWebsite, defaultLanguage))
+        class Get : EditCommand(name = "get", actionDescription = "Fetches app details for this edit. This includes the default language and developer support contact information") {
+            override fun run(api: PlayStoreApi) = api.detailsGet(EditModel(packageName, editId))
         }
 
-        class Update : BaseCommand(name = "update", actionDescription = "Updates app details for this edit") {
+        class Patch : EditCommand(name = "patch", actionDescription = "Updates app details for this edit") {
             private val contactEmail: String? by option("--contact-email", "-e", help = "The user-visible support email for this app")
             private val contactPhone: String? by option("--contact-phone", help = "The user-visible support telephone number for this app")
             private val contactWebsite: String? by option("--contact-website", "-w", help = "The user-visible website for this app")
             private val defaultLanguage: String? by option("--default-language", "-l", help = "Default language code, in BCP 47 format (eg \"en-US\").")
 
-            override fun run(api: PlayStoreApi) = api.detailsUpdate(DetailsUpdateModel(packageName, contactEmail, contactPhone, contactWebsite, defaultLanguage))
+            override fun run(api: PlayStoreApi) = api.detailsPatch(DetailsPatchModel(packageName, editId, contactEmail, contactPhone, contactWebsite, defaultLanguage))
+        }
+
+        class Update : EditCommand(name = "update", actionDescription = "Updates app details for this edit") {
+            private val contactEmail: String? by option("--contact-email", "-e", help = "The user-visible support email for this app")
+            private val contactPhone: String? by option("--contact-phone", help = "The user-visible support telephone number for this app")
+            private val contactWebsite: String? by option("--contact-website", "-w", help = "The user-visible website for this app")
+            private val defaultLanguage: String? by option("--default-language", "-l", help = "Default language code, in BCP 47 format (eg \"en-US\").")
+
+            override fun run(api: PlayStoreApi) = api.detailsUpdate(DetailsUpdateModel(packageName, editId, contactEmail, contactPhone, contactWebsite, defaultLanguage))
+        }
+    }
+
+    object Edits {
+        class Create : BaseCommand(name = "create", actionDescription = "Create a new edit") {
+            override fun run(api: PlayStoreApi) = api.editCreate(DefaultModel(packageName))
+        }
+
+        class Commit : EditCommand(name = "commit", actionDescription = "") {
+            override fun run(api: PlayStoreApi) = api.editCommit(EditModel(packageName, editId))
+        }
+
+        class Validate : EditCommand(name = "validate", actionDescription = "") {
+            override fun run(api: PlayStoreApi) = api.editValidate(EditModel(packageName, editId))
         }
     }
 
     object ExpansionFiles {
-        class Get : BaseCommand(name = "get", actionDescription = "Fetches the Expansion File configuration for the APK specified") {
+        class Get : EditCommand(name = "get", actionDescription = "Fetches the Expansion File configuration for the APK specified") {
             val apkVersionCode: Int by option("--apk-version-code", "-v", help = "The version code of the APK whose Expansion File configuration is being read or modified").int().required()
             private val expansionFileType: String by option("--expansion-file-type", "-t").choice("main", "patch").default("main")
 
-            override fun run(api: PlayStoreApi) = api.expansionFilesGet(ExpansionFilesGetModel(packageName, apkVersionCode, expansionFileType))
+            override fun run(api: PlayStoreApi) = api.expansionFilesGet(ExpansionFilesGetModel(packageName, editId, apkVersionCode, expansionFileType))
         }
 
-        class Patch : BaseCommand(name = "patch", actionDescription = "Updates the APK's Expansion File configuration to reference another APK's Expansion Files. To add a new Expansion File use the Upload method") {
+        class Patch : EditCommand(name = "patch", actionDescription = "Updates the APK's Expansion File configuration to reference another APK's Expansion Files. To add a new Expansion File use the Upload method") {
             val apkVersionCode: Int by option("--apk-version-code", "-v", help = "The version code of the APK whose Expansion File configuration is being read or modified").int().required()
             private val expansionFileType: String by option("--expansion-file-type", "-t").choice("main", "patch").default("main")
             private val referencesVersion: Int? by option("--references-version", "-r").int()
             private val fileSize: Long? by option("--file-size", "-s").long()
 
-            override fun run(api: PlayStoreApi) = api.expansionFilesPatch(ExpansionFilesPatchModel(packageName, apkVersionCode, expansionFileType, referencesVersion, fileSize))
+            override fun run(api: PlayStoreApi) = api.expansionFilesPatch(ExpansionFilesPatchModel(packageName, editId, apkVersionCode, expansionFileType, referencesVersion, fileSize))
         }
 
-        class Update : BaseCommand(name = "update", actionDescription = "Updates the APK's Expansion File configuration to reference another APK's Expansion Files. To add a new Expansion File use the Upload method") {
+        class Update : EditCommand(name = "update", actionDescription = "Updates the APK's Expansion File configuration to reference another APK's Expansion Files. To add a new Expansion File use the Upload method") {
             val apkVersionCode: Int by option("--apk-version-code", "-v", help = "The version code of the APK whose Expansion File configuration is being read or modified").int().required()
             private val expansionFileType: String by option("--expansion-file-type", "-t").choice("main", "patch").default("main")
             private val referencesVersion: Int by option("--references-version", "-r").int().default(0)
             private val fileSize: Long by option("--file-size", "-s").long().default(0L)
 
-            override fun run(api: PlayStoreApi) = api.expansionFilesUpdate(ExpansionFilesUpdateModel(packageName, apkVersionCode, expansionFileType, referencesVersion, fileSize))
+            override fun run(api: PlayStoreApi) = api.expansionFilesUpdate(ExpansionFilesUpdateModel(packageName, editId, apkVersionCode, expansionFileType, referencesVersion, fileSize))
         }
 
-        class Upload : BaseCommand(name = "upload", actionDescription = "Uploads and attaches a new Expansion File to the APK specified") {
+        class Upload : EditCommand(name = "upload", actionDescription = "Uploads and attaches a new Expansion File to the APK specified") {
             val apkVersionCode: Int by option("--apk-version-code", "-v", help = "The version code of the APK whose Expansion File configuration is being read or modified").int().required()
             private val expansionFileType: String by option("--expansion-file-type", "-t").choice("main", "patch").default("main")
             private val expansionFile: File by option("--expansion-file", "-f", help = "Expansion file patch").file().required()
 
-            override fun run(api: PlayStoreApi) = api.expansionFilesUpload(ExpansionFilesUploadModel(packageName, apkVersionCode, expansionFileType, expansionFile))
+            override fun run(api: PlayStoreApi) = api.expansionFilesUpload(ExpansionFilesUploadModel(packageName, editId, apkVersionCode, expansionFileType, expansionFile))
         }
     }
 
     object Images {
-        class List : BaseCommand(name = "list", actionDescription = "Lists all images for the specified language and image type") {
+        class List : EditCommand(name = "list", actionDescription = "Lists all images for the specified language and image type") {
             private val imageType: String by option("--image-type", "-t")
                     .choice("featureGraphic", "icon", "phoneScreenshots", "promoGraphic", "sevenInchScreenshots", "tenInchScreenshots", "tvBanner", "tvScreenshots", "wearScreenshots").required()
             val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing whose images you want to list. For example, to select Latin American Spanish, pass \"es-419\".").required()
 
 
-            override fun run(api: PlayStoreApi) = api.imagesList(ImagesListModel(packageName, imageType, language))
+            override fun run(api: PlayStoreApi) = api.imagesList(ImagesListModel(packageName, editId, imageType, language))
         }
 
-        class Delete : BaseCommand(name = "delete", actionDescription = "Deletes the image (specified by id) from the edit") {
+        class Delete : EditCommand(name = "delete", actionDescription = "Deletes the image (specified by id) from the edit") {
             private val imageType: String by option("--image-type", "-t")
                     .choice("featureGraphic", "icon", "phoneScreenshots", "promoGraphic", "sevenInchScreenshots", "tenInchScreenshots", "tvBanner", "tvScreenshots", "wearScreenshots").required()
             val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing whose images you want to list. For example, to select Latin American Spanish, pass \"es-419\".").required()
             private val imageId: String by option("--image-id", "-i").required()
 
-            override fun run(api: PlayStoreApi) = api.imagesDelete(ImagesDeleteModel(packageName, imageType, language, imageId))
+            override fun run(api: PlayStoreApi) = api.imagesDelete(ImagesDeleteModel(packageName, editId, imageType, language, imageId))
         }
 
-        class DeleteAll : BaseCommand(name = "delete-all", actionDescription = "Deletes all images for the specified language and image type") {
+        class DeleteAll : EditCommand(name = "delete-all", actionDescription = "Deletes all images for the specified language and image type") {
             private val imageType: String by option("--image-type", "-t")
                     .choice("featureGraphic", "icon", "phoneScreenshots", "promoGraphic", "sevenInchScreenshots", "tenInchScreenshots", "tvBanner", "tvScreenshots", "wearScreenshots").required()
             val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing whose images you want to list. For example, to select Latin American Spanish, pass \"es-419\".").required()
 
-            override fun run(api: PlayStoreApi) = api.imagesDeleteAll(ImagesDeleteAllModel(packageName, imageType, language))
+            override fun run(api: PlayStoreApi) = api.imagesDeleteAll(ImagesDeleteAllModel(packageName, editId, imageType, language))
         }
 
-        class Upload : BaseCommand(name = "upload", actionDescription = "Uploads a new image and adds it to the list of images for the specified language and image type") {
+        class Upload : EditCommand(name = "upload", actionDescription = "Uploads a new image and adds it to the list of images for the specified language and image type") {
             private val image: File by option("--image", "-i", help = "Image file path").file().required()
             private val imageType: String by option("--image-type", "-t")
                     .choice("featureGraphic", "icon", "phoneScreenshots", "promoGraphic", "sevenInchScreenshots", "tenInchScreenshots", "tvBanner", "tvScreenshots", "wearScreenshots").required()
             val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing whose images you want to list. For example, to select Latin American Spanish, pass \"es-419\".").required()
 
-            override fun run(api: PlayStoreApi) = api.imagesUploadAll(ImagesUploadModel(packageName, imageType, language, image))
+            override fun run(api: PlayStoreApi) = api.imagesUploadAll(ImagesUploadModel(packageName, editId, imageType, language, image))
         }
     }
 
     object Listings {
-        class Get : BaseCommand(name = "get", actionDescription = "Fetches information about a localized store listing") {
+        class DeleteAll : EditCommand(name = "deleteAll", actionDescription = "Deletes all localized listings from an edit") {
             val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing to read or modify. For example, to select Latin American Spanish, pass \"es-419\".").required()
 
-            override fun run(api: PlayStoreApi) = api.listingsGet(ListingsGetModel(packageName, language))
+            override fun run(api: PlayStoreApi) = api.listingsDeleteAll(EditModel(packageName, editId))
         }
 
-        class Delete : BaseCommand(name = "delete", actionDescription = "Deletes the specified localized store listing from an edit") {
+        class List : EditCommand(name = "list", actionDescription = "Returns all of the localized store listings attached to this edit") {
             val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing to read or modify. For example, to select Latin American Spanish, pass \"es-419\".").required()
 
-            override fun run(api: PlayStoreApi) = api.listingsDelete(ListingsDeleteModel(packageName, language))
+            override fun run(api: PlayStoreApi) = api.listingsList(EditModel(packageName, editId))
         }
 
-        class Update : BaseCommand(name = "update", actionDescription = "Creates or updates a localized store listing") {
+        class Get : EditCommand(name = "get", actionDescription = "Fetches information about a localized store listing") {
+            val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing to read or modify. For example, to select Latin American Spanish, pass \"es-419\".").required()
+
+            override fun run(api: PlayStoreApi) = api.listingsGet(ListingsGetModel(packageName, editId, language))
+        }
+
+        class Delete : EditCommand(name = "delete", actionDescription = "Deletes the specified localized store listing from an edit") {
+            val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing to read or modify. For example, to select Latin American Spanish, pass \"es-419\".").required()
+
+            override fun run(api: PlayStoreApi) = api.listingsDelete(ListingsDeleteModel(packageName, editId, language))
+        }
+
+        class Update : EditCommand(name = "update", actionDescription = "Creates or updates a localized store listing") {
             val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing to read or modify. For example, to select Latin American Spanish, pass \"es-419\".").required()
             private val fullDescription: String by option("--full-description", "-d", help = "Full description of the app; this may be up to 4000 characters in length.").default("").validate { it.length <= 4000 }
             private val shortDescription: String by option("--short-description", "-s", help = "Short description of the app (previously known as promo text); this may be up to 80 characters in length.").default("").validate { it.length <= 80 }
             private val title: String by option("--title", "-t", help = "App's localized title.").default("")
             private val video: String by option("--video-url", "-v", help = "URL of a promotional YouTube video for the app.").default("")
 
-            override fun run(api: PlayStoreApi) = api.listingsUpdate(ListingsUpdateModel(packageName, language, fullDescription, shortDescription, title, video))
+            override fun run(api: PlayStoreApi) = api.listingsUpdate(ListingsUpdateModel(packageName, editId, language, fullDescription, shortDescription, title, video))
         }
 
-        class Patch : BaseCommand(name = "patch", actionDescription = "Creates or updates a localized store listing") {
+        class Patch : EditCommand(name = "patch", actionDescription = "Creates or updates a localized store listing") {
             val language: String? by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing to read or modify. For example, to select Latin American Spanish, pass \"es-419\".")
             private val fullDescription: String? by option("--full-description", "-d", help = "Full description of the app; this may be up to 4000 characters in length.").validate { it.length <= 4000 }
             private val shortDescription: String? by option("--short-description", "-s", help = "Short description of the app (previously known as promo text); this may be up to 80 characters in length.").validate { it.length <= 80 }
             private val title: String? by option("--title", "-t", help = "App's localized title.")
             private val video: String? by option("--video-url", "-v", help = "URL of a promotional YouTube video for the app.")
 
-            override fun run(api: PlayStoreApi) = api.listingsPatch(ListingsPatchModel(packageName, language, fullDescription, shortDescription, title, video))
+            override fun run(api: PlayStoreApi) = api.listingsPatch(ListingsPatchModel(packageName, editId, language, fullDescription, shortDescription, title, video))
         }
     }
 
     object Testers {
-        class Get : BaseCommand(name = "get") {
+        class Get : EditCommand(name = "get") {
             private val track: String by option("--track", "-t").required()
 
-            override fun run(api: PlayStoreApi) = api.testersGet(TestersGetModel(packageName, track))
+            override fun run(api: PlayStoreApi) = api.testersGet(TestersGetModel(packageName, editId, track))
         }
 
-        class Update : BaseCommand(name = "update") {
+        class Update : EditCommand(name = "update") {
             private val track: String by option("--track", "-t").required()
             private val googleGroups: List<String> by option("--google-group", "-g").multiple()
             private val googlePlusCommunities: List<String> by option("--google-plus-communities").multiple()
 
-            override fun run(api: PlayStoreApi) = api.testersUpdate(TestersUpdateModel(packageName, track, googleGroups, googlePlusCommunities))
+            override fun run(api: PlayStoreApi) = api.testersUpdate(TestersUpdateModel(packageName, editId, track, googleGroups, googlePlusCommunities))
         }
 
-        class Patch : BaseCommand(name = "patch") {
+        class Patch : EditCommand(name = "patch") {
             private val track: String by option("--track", "-t").required()
             private val googleGroups: List<String> by option("--google-group", "-g").multiple()
             private val googlePlusCommunities: List<String> by option("--google-plus-communities").multiple()
 
-            override fun run(api: PlayStoreApi) = api.testersPatch(TestersPatchModel(packageName, track, googleGroups, googlePlusCommunities))
+            override fun run(api: PlayStoreApi) = api.testersPatch(TestersPatchModel(packageName, editId, track, googleGroups, googlePlusCommunities))
         }
     }
 
     object Tracks {
-        class Get : BaseCommand(name = "get", actionDescription = "Fetches the track configuration for the specified track type. Includes the APK version codes that are in this track") {
-            private val track: String by option("--track", "-t").required()
-
-            override fun run(api: PlayStoreApi) = api.tracksGet(TracksGetModel(packageName, track))
+        class List : EditCommand(name = "list", actionDescription = "Lists all the track configurations for this edit") {
+            override fun run(api: PlayStoreApi) = api.tracksList(EditModel(packageName, editId))
         }
 
-        class Patch : BaseCommand(name = "patch", actionDescription = "Updates the track configuration for the specified track type") {
+        class Get : EditCommand(name = "get", actionDescription = "Fetches the track configuration for the specified track type. Includes the APK version codes that are in this track") {
+            private val track: String by option("--track", "-t").required()
+
+            override fun run(api: PlayStoreApi) = api.tracksGet(TracksGetModel(packageName, editId, track))
+        }
+
+        class Patch : EditCommand(name = "patch", actionDescription = "Updates the track configuration for the specified track type") {
             private val track: String by option("--track", "-t").required()
             val apkVersionCode: Int by option("--apk-version-code", "-v", help = "The version code of the APK whose will be promoted to the track").int().required()
             private val userFraction: Double by option("--user-fraction", "-f", help = "Fraction of users who are eligible to receive the release. 0 < fraction < 1. To be set, release status must be \"inProgress\" or \"halted\".").double().default(1.0)
 
-            override fun run(api: PlayStoreApi) = api.tracksPatch(TracksPatchModel(packageName, track, apkVersionCode, userFraction))
+            override fun run(api: PlayStoreApi) = api.tracksPatch(TracksPatchModel(packageName, editId, track, apkVersionCode, userFraction))
         }
 
-        class Update : BaseCommand(name = "update", actionDescription = "Updates the track configuration for the specified track type") {
+        class Update : EditCommand(name = "update", actionDescription = "Updates the track configuration for the specified track type") {
             private val track: String by option("--track", "-t").required()
             val apkVersionCode: Int by option("--apk-version-code", "-v", help = "The version code of the APK whose will be promoted to the track").int().required()
             private val userFraction: Double by option("--user-fraction", "-f", help = "Fraction of users who are eligible to receive the release. 0 < fraction < 1. To be set, release status must be \"inProgress\" or \"halted\".").double().default(1.0)
 
-            override fun run(api: PlayStoreApi) = api.tracksUpdate(TracksUpdateModel(packageName, track, apkVersionCode, userFraction))
+            override fun run(api: PlayStoreApi) = api.tracksUpdate(TracksUpdateModel(packageName, editId, track, apkVersionCode, userFraction))
         }
     }
 
     object Reviews {
-        class List : BaseCommand(name = "list", actionDescription = "Returns a list of reviews. Only reviews from last week will be returned") {
+        class List : EditCommand(name = "list", actionDescription = "Returns a list of reviews. Only reviews from last week will be returned") {
             private val maxResults: Long by option("--max-results", "-m").long().default(100L)
             private val startIndex: Long by option("--start-index", "-s").long().default(0L)
             private val translationLanguage: String by option("--translation-language", "-l").default("")
             private val token: String by option("--token", "-t").default("")
 
-            override fun run(api: PlayStoreApi) = api.reviewsList(ReviewsListModel(packageName, maxResults, startIndex, token, translationLanguage))
+            override fun run(api: PlayStoreApi) = api.reviewsList(ReviewsListModel(packageName, editId, maxResults, startIndex, token, translationLanguage))
         }
 
-        class Get : BaseCommand(name = "get", actionDescription = "Returns a single review") {
+        class Get : EditCommand(name = "get", actionDescription = "Returns a single review") {
             private val reviewId: String by option("--review-id", "-r").required()
             private val translationLanguage: String by option("--translation-language", "-l").default("")
 
-            override fun run(api: PlayStoreApi) = api.reviewsGet(ReviewsGetModel(packageName, reviewId, translationLanguage))
+            override fun run(api: PlayStoreApi) = api.reviewsGet(ReviewsGetModel(packageName, editId, reviewId, translationLanguage))
         }
 
-        class Reply : BaseCommand(name = "reply", actionDescription = "Reply to a single review, or update an existing reply") {
+        class Reply : EditCommand(name = "reply", actionDescription = "Reply to a single review, or update an existing reply") {
             private val reviewId: String by option("--review-id", "-r").required()
             private val replyText: String by option("--reply-text", "-a").required()
 
-            override fun run(api: PlayStoreApi) = api.reviewsReply(ReviewsReplyModel(packageName, reviewId, replyText))
+            override fun run(api: PlayStoreApi) = api.reviewsReply(ReviewsReplyModel(packageName, editId, reviewId, replyText))
         }
     }
 
@@ -256,11 +299,11 @@ object Commands {
     }
 
     object Orders {
-        class Refund : BaseCommand(name = "refund", actionDescription = "Refund a user's subscription or in-app purchase order") {
+        class Refund : EditCommand(name = "refund", actionDescription = "Refund a user's subscription or in-app purchase order") {
             private val orderId: String by option("--order-id", "-o", help = "The order ID provided to the user when the subscription or in-app order was purchased").required()
             private val revoke: Boolean by option("--revoke", "-l", help = "Whether to revoke the purchased item. If set to true, access to the subscription or in-app item will be terminated immediately. If the item is a recurring subscription, all future payments will also be terminated. Consumed in-app items need to be handled by developer's app. (optional)").flag()
 
-            override fun run(api: PlayStoreApi) = api.ordersRefund(OrdersRefundModel(packageName, orderId, revoke))
+            override fun run(api: PlayStoreApi) = api.ordersRefund(OrdersRefundModel(packageName, editId, orderId, revoke))
         }
     }
 

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/Commands.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/Commands.kt
@@ -163,14 +163,10 @@ object Commands {
 
     object Listings {
         class DeleteAll : EditCommand(name = "deleteAll", actionDescription = "Deletes all localized listings from an edit") {
-            val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing to read or modify. For example, to select Latin American Spanish, pass \"es-419\".").required()
-
             override fun run(api: PlayStoreApi) = api.listingsDeleteAll(EditModel(packageName, editId))
         }
 
         class List : EditCommand(name = "list", actionDescription = "Returns all of the localized store listings attached to this edit") {
-            val language: String by option("--language", "-l", help = "The language code (a BCP-47 language tag) of the localized listing to read or modify. For example, to select Latin American Spanish, pass \"es-419\".").required()
-
             override fun run(api: PlayStoreApi) = api.listingsList(EditModel(packageName, editId))
         }
 

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/PlayStoreApi.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/PlayStoreApi.kt
@@ -11,6 +11,7 @@ import java.io.File
 import java.io.FileInputStream
 
 class PlayStoreApi(serviceAccountJson: File, appName: String) :
+        Edit,
         Apks,
         Bundles,
         Deobfuscationfiles,

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/PlayStoreCli.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/PlayStoreCli.kt
@@ -1,28 +1,31 @@
 package com.github.vacxe.googleplaycli
 
-import com.github.vacxe.googleplaycli.actions.model.DefaultModel
 import com.github.vacxe.googleplaycli.dsl.addCmd
-import com.github.vacxe.googleplaycli.dsl.baseCmd
 import com.github.vacxe.googleplaycli.dsl.cmd
 import com.github.vacxe.googleplaycli.dsl.subcmd
 
 fun main(args: Array<String>) {
     cmd("google-play-cli") {
         subcmd("apk") {
-            baseCmd("list", "Lists all current APKs for the specified package and edit") { it.apksList(DefaultModel(packageName)) }
+            addCmd { Commands.Apks.List() }
             addCmd { Commands.Apks.Upload() }
         }
         subcmd("bundles") {
-            baseCmd("list") { it.bundlesList(DefaultModel(packageName)) }
+            addCmd { Commands.Bundles.List() }
             addCmd { Commands.Bundles.Upload() }
         }
         subcmd("deobfuscation-files") {
             addCmd { Commands.Deobfuscationfiles.Upload() }
         }
         subcmd("details") {
-            baseCmd("get", "Fetches app details for this edit. This includes the default language and developer support contact information") { it.detailsGet(DefaultModel(packageName)) }
+            addCmd { Commands.Details.Get() }
             addCmd { Commands.Details.Patch() }
             addCmd { Commands.Details.Update() }
+        }
+        subcmd("edit") {
+            addCmd { Commands.Edits.Create() }
+            addCmd { Commands.Edits.Validate() }
+            addCmd { Commands.Edits.Commit() }
         }
         subcmd("expansion-files") {
             addCmd { Commands.ExpansionFiles.Get() }
@@ -37,8 +40,8 @@ fun main(args: Array<String>) {
             addCmd { Commands.Images.Upload() }
         }
         subcmd("listings") {
-            baseCmd("deleteAll", "Deletes all localized listings from an edit") { it.listingsDeleteAll(DefaultModel(packageName)) }
-            baseCmd("list", "Returns all of the localized store listings attached to this edit") { it.listingsList(DefaultModel(packageName)) }
+            addCmd { Commands.Listings.DeleteAll() }
+            addCmd { Commands.Listings.List() }
             addCmd { Commands.Listings.Get() }
             addCmd { Commands.Listings.Delete() }
             addCmd { Commands.Listings.Update() }
@@ -51,7 +54,7 @@ fun main(args: Array<String>) {
         }
         subcmd("tracks") {
             addCmd { Commands.Tracks.Get() }
-            baseCmd("list", "Lists all the track configurations for this edit") { it.tracksList(DefaultModel(packageName)) }
+            addCmd { Commands.Tracks.List() }
             addCmd { Commands.Tracks.Patch() }
             addCmd { Commands.Tracks.Update() }
         }

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Apks.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Apks.kt
@@ -1,7 +1,7 @@
 package com.github.vacxe.googleplaycli.actions
 
 import com.github.vacxe.googleplaycli.actions.model.ApksUploadModel
-import com.github.vacxe.googleplaycli.actions.model.DefaultModel
+import com.github.vacxe.googleplaycli.actions.model.EditModel
 import com.github.vacxe.googleplaycli.core.constants.MediaType.MIME_TYPE_APK
 import com.google.api.client.http.AbstractInputStreamContent
 import com.google.api.client.http.FileContent
@@ -10,16 +10,16 @@ import com.google.api.services.androidpublisher.model.Apk
 import com.google.api.services.androidpublisher.model.ApksListResponse
 
 interface Apks : BaseAction {
-    fun apksList(model: DefaultModel): ApksListResponse {
+    fun apksList(model: EditModel): ApksListResponse {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.apks().list(model.packageName, insert.id).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.apks().list(model.packageName, editId).execute()
     }
 
     fun apksUpload(model: ApksUploadModel): Apk {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val apkFile: AbstractInputStreamContent = FileContent(MIME_TYPE_APK, model.apk)
-        return edits.apks().upload(model.packageName, insert.id, apkFile).execute()
+        return edits.apks().upload(model.packageName, editId, apkFile).execute()
     }
 }

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Bundles.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Bundles.kt
@@ -1,7 +1,7 @@
 package com.github.vacxe.googleplaycli.actions
 
 import com.github.vacxe.googleplaycli.actions.model.BundlesUploadModel
-import com.github.vacxe.googleplaycli.actions.model.DefaultModel
+import com.github.vacxe.googleplaycli.actions.model.EditModel
 import com.github.vacxe.googleplaycli.core.constants.MediaType.MIME_TYPE_APK
 import com.google.api.client.http.AbstractInputStreamContent
 import com.google.api.client.http.FileContent
@@ -10,17 +10,17 @@ import com.google.api.services.androidpublisher.model.Bundle
 import com.google.api.services.androidpublisher.model.BundlesListResponse
 
 interface Bundles : BaseAction {
-    fun bundlesList(model: DefaultModel): BundlesListResponse {
+    fun bundlesList(model: EditModel): BundlesListResponse {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.bundles().list(model.packageName, insert.id).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.bundles().list(model.packageName, editId).execute()
     }
 
     fun bundlesUpload(model: BundlesUploadModel): Bundle {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val apkFile: AbstractInputStreamContent = FileContent(MIME_TYPE_APK, model.bundle)
-        return edits.bundles().upload(model.packageName, insert.id, apkFile)
+        return edits.bundles().upload(model.packageName, editId, apkFile)
                 .apply { ackBundleInstallationWarning = model.ackBundleInstallationWarning }
                 .execute()
     }

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Deobfuscationfiles.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Deobfuscationfiles.kt
@@ -10,8 +10,8 @@ import com.google.api.services.androidpublisher.model.DeobfuscationFilesUploadRe
 interface Deobfuscationfiles : BaseAction {
     fun deobfuscationFilesUpload(model: DeobfuscationfilesUploadModel): DeobfuscationFilesUploadResponse {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val deobfuscation: AbstractInputStreamContent = FileContent(MIME_TYPE_APK, model.deobfuscation)
-        return edits.deobfuscationfiles().upload(model.packageName, insert.id, model.apkVersionCode, model.deobfuscationFileType, deobfuscation).execute()
+        return edits.deobfuscationfiles().upload(model.packageName, editId, model.apkVersionCode, model.deobfuscationFileType, deobfuscation).execute()
     }
 }

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Details.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Details.kt
@@ -1,40 +1,40 @@
 package com.github.vacxe.googleplaycli.actions
 
-import com.github.vacxe.googleplaycli.actions.model.DefaultModel
 import com.github.vacxe.googleplaycli.actions.model.DetailsPatchModel
 import com.github.vacxe.googleplaycli.actions.model.DetailsUpdateModel
+import com.github.vacxe.googleplaycli.actions.model.EditModel
 import com.google.api.services.androidpublisher.AndroidPublisher
 import com.google.api.services.androidpublisher.model.AppDetails
 
 interface Details : BaseAction {
-    fun detailsGet(model: DefaultModel): AppDetails {
+    fun detailsGet(model: EditModel): AppDetails {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.details().get(model.packageName, insert.id).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.details().get(model.packageName, editId).execute()
     }
 
     fun detailsPatch(model: DetailsPatchModel): AppDetails {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val appDetails = AppDetails().apply {
             model.contactEmail?.let { contactEmail = it }
             model.contactPhone?.let { contactPhone = it }
             model.contactWebsite?.let { contactWebsite = it }
             model.defaultLanguage?.let { defaultLanguage = it }
         }
-        return edits.details().patch(model.packageName, insert.id, appDetails).execute()
+        return edits.details().patch(model.packageName, editId, appDetails).execute()
     }
 
     fun detailsUpdate(model: DetailsUpdateModel): AppDetails {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val appDetails = AppDetails().apply {
             model.contactEmail?.let { contactEmail = it }
             model.contactPhone?.let { contactPhone = it }
             model.contactWebsite?.let { contactWebsite = it }
             model.defaultLanguage?.let { defaultLanguage = it }
         }
-        return edits.details().update(model.packageName, insert.id, appDetails).execute()
+        return edits.details().update(model.packageName, editId, appDetails).execute()
     }
 
 }

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Edit.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Edit.kt
@@ -1,0 +1,24 @@
+package com.github.vacxe.googleplaycli.actions
+
+import com.github.vacxe.googleplaycli.actions.model.DefaultModel
+import com.github.vacxe.googleplaycli.actions.model.EditModel
+import com.google.api.services.androidpublisher.AndroidPublisher
+import com.google.api.services.androidpublisher.model.AppEdit
+
+interface Edit: BaseAction {
+    fun editCreate(model: DefaultModel): String {
+        val edits: AndroidPublisher.Edits = androidPublisher.edits()
+        val insert = edits.insert(model.packageName, null).execute()
+        return insert.id
+    }
+
+    fun editCommit(model: EditModel): AppEdit {
+        val edits: AndroidPublisher.Edits = androidPublisher.edits()
+        return edits.commit(model.packageName, model.editId).execute()
+    }
+
+    fun editValidate(model: EditModel): AppEdit {
+        val edits: AndroidPublisher.Edits = androidPublisher.edits()
+        return edits.validate(model.packageName, model.editId).execute()
+    }
+}

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/ExpansionFiles.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/ExpansionFiles.kt
@@ -14,13 +14,13 @@ import com.google.api.services.androidpublisher.model.ExpansionFilesUploadRespon
 interface ExpansionFiles : BaseAction {
     fun expansionFilesGet(model: ExpansionFilesGetModel): ExpansionFile {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.expansionfiles().get(model.packageName, insert.id, model.apkVersionCode, model.expansionFileType).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.expansionfiles().get(model.packageName, editId, model.apkVersionCode, model.expansionFileType).execute()
     }
 
     fun expansionFilesPatch(model: ExpansionFilesPatchModel): ExpansionFile {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val expansionFile = ExpansionFile().apply {
             model.fileSize?.let { fileSize = it }
             model.referencesVersion?.let { referencesVersion = it }
@@ -29,7 +29,7 @@ interface ExpansionFiles : BaseAction {
         return edits.expansionfiles()
                 .patch(
                         model.packageName,
-                        insert.id,
+                        editId,
                         model.apkVersionCode,
                         model.expansionFileType,
                         expansionFile)
@@ -38,7 +38,7 @@ interface ExpansionFiles : BaseAction {
 
     fun expansionFilesUpdate(model: ExpansionFilesUpdateModel): ExpansionFile {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val expansionFile = ExpansionFile().apply {
             fileSize = model.fileSize
             referencesVersion = model.referencesVersion
@@ -47,7 +47,7 @@ interface ExpansionFiles : BaseAction {
         return edits.expansionfiles()
                 .update(
                         model.packageName,
-                        insert.id,
+                        editId,
                         model.apkVersionCode,
                         model.expansionFileType,
                         expansionFile)
@@ -56,13 +56,13 @@ interface ExpansionFiles : BaseAction {
 
     fun expansionFilesUpload(model: ExpansionFilesUploadModel): ExpansionFilesUploadResponse {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val expansionFile: AbstractInputStreamContent = FileContent(MediaType.MIME_TYPE_APK, model.expansionFile)
 
         return edits.expansionfiles()
                 .upload(
                         model.packageName,
-                        insert.id,
+                        editId,
                         model.apkVersionCode,
                         model.expansionFileType,
                         expansionFile)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Images.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Images.kt
@@ -15,26 +15,26 @@ import com.google.api.services.androidpublisher.model.ImagesUploadResponse
 interface Images : BaseAction {
     fun imagesList(model: ImagesListModel): ImagesListResponse {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.images().list(model.packageName, insert.id, model.language, model.imageType).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.images().list(model.packageName, editId, model.language, model.imageType).execute()
     }
 
     fun imagesDelete(model: ImagesDeleteModel): Void {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.images().delete(model.packageName, insert.id, model.language, model.imageType, model.imageId).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.images().delete(model.packageName, editId, model.language, model.imageType, model.imageId).execute()
     }
 
     fun imagesDeleteAll(model: ImagesDeleteAllModel): ImagesDeleteAllResponse {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.images().deleteall(model.packageName, insert.id, model.language, model.imageType).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.images().deleteall(model.packageName, editId, model.language, model.imageType).execute()
     }
 
     fun imagesUploadAll(model: ImagesUploadModel): ImagesUploadResponse {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val image: AbstractInputStreamContent = FileContent(MediaType.MIME_TYPE_PNG, model.image)
-        return edits.images().upload(model.packageName, insert.id, model.language, model.imageType, image).execute()
+        return edits.images().upload(model.packageName, editId, model.language, model.imageType, image).execute()
     }
 }

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Inappproducts.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Inappproducts.kt
@@ -1,11 +1,6 @@
 package com.github.vacxe.googleplaycli.actions
 
-import com.github.vacxe.googleplaycli.actions.model.DefaultModel
-import com.github.vacxe.googleplaycli.actions.model.InappproductsDeleteModel
-import com.github.vacxe.googleplaycli.actions.model.InappproductsGetModel
-import com.github.vacxe.googleplaycli.actions.model.InappproductsInsertModel
-import com.github.vacxe.googleplaycli.actions.model.InappproductsPatchModel
-import com.github.vacxe.googleplaycli.actions.model.InappproductsUpdateModel
+import com.github.vacxe.googleplaycli.actions.model.*
 import com.google.api.services.androidpublisher.model.InAppProduct
 import com.google.api.services.androidpublisher.model.InappproductsListResponse
 import java.nio.file.Files

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Listings.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Listings.kt
@@ -6,51 +6,51 @@ import com.google.api.services.androidpublisher.model.Listing
 import com.google.api.services.androidpublisher.model.ListingsListResponse
 
 interface Listings : BaseAction {
-    fun listingsList(model: DefaultModel): ListingsListResponse {
+    fun listingsList(model: EditModel): ListingsListResponse {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.listings().list(model.packageName, insert.id).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.listings().list(model.packageName, editId).execute()
     }
 
-    fun listingsDeleteAll(model: DefaultModel): Void {
+    fun listingsDeleteAll(model: EditModel): Void {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.listings().deleteall(model.packageName, insert.id).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.listings().deleteall(model.packageName, editId).execute()
     }
 
     fun listingsDelete(model: ListingsDeleteModel): Void {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.listings().delete(model.packageName, insert.id, model.language).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.listings().delete(model.packageName, editId, model.language).execute()
     }
 
     fun listingsGet(model: ListingsGetModel): Listing {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.listings().get(model.packageName, insert.id, model.language).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.listings().get(model.packageName, editId, model.language).execute()
     }
 
     fun listingsUpdate(model: ListingsUpdateModel): Listing {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val listing = Listing().apply {
             fullDescription = model.fullDescription
             shortDescription = model.shortDescription
             title = model.title
             video = model.video
         }
-        return edits.listings().update(model.packageName, insert.id, model.language, listing).execute()
+        return edits.listings().update(model.packageName, editId, model.language, listing).execute()
     }
 
     fun listingsPatch(model: ListingsPatchModel): Listing {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val listing = Listing().apply {
             model.fullDescription?.let { fullDescription = it }
             model.shortDescription?.let { shortDescription = it }
             model.title?.let { title = it }
             model.video?.let { video = it }
         }
-        return edits.listings().update(model.packageName, insert.id, model.language, listing).execute()
+        return edits.listings().update(model.packageName, editId, model.language, listing).execute()
     }
 }

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Testers.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Testers.kt
@@ -10,27 +10,27 @@ interface Testers : BaseAction {
 
     fun testersGet(model: TestersGetModel): Testers {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.testers().get(model.packageName, insert.id, model.track).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.testers().get(model.packageName, editId, model.track).execute()
     }
 
     fun testersUpdate(model: TestersUpdateModel): Testers {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val testers = Testers().apply {
             googleGroups = model.googleGroups
             googlePlusCommunities = model.googlePlusCommunities
         }
-        return edits.testers().update(model.packageName, insert.id, model.track, testers).execute()
+        return edits.testers().update(model.packageName, editId, model.track, testers).execute()
     }
 
     fun testersPatch(model: TestersPatchModel): Testers {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
         val testers = Testers().apply {
             model.googleGroups?.let { googleGroups = it }
             model.googlePlusCommunities?.let { googlePlusCommunities = it }
         }
-        return edits.testers().update(model.packageName, insert.id, model.track, testers).execute()
+        return edits.testers().update(model.packageName, editId, model.track, testers).execute()
     }
 }

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Tracks.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Tracks.kt
@@ -37,6 +37,7 @@ interface Tracks : BaseAction {
 
     fun tracksUpdate(model: TracksUpdateModel): Track {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
 
         val release = TrackRelease()
                 .setVersionCodes(listOf(model.apkVersionCode.toLong()))
@@ -44,6 +45,6 @@ interface Tracks : BaseAction {
 
         val track = Track().setReleases(listOf(release))
 
-        return edits.tracks().update(model.packageName, model.editId, model.track, track).execute()
+        return edits.tracks().update(model.packageName, editId, model.track, track).execute()
     }
 }

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Tracks.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/Tracks.kt
@@ -1,6 +1,6 @@
 package com.github.vacxe.googleplaycli.actions
 
-import com.github.vacxe.googleplaycli.actions.model.DefaultModel
+import com.github.vacxe.googleplaycli.actions.model.EditModel
 import com.github.vacxe.googleplaycli.actions.model.TracksGetModel
 import com.github.vacxe.googleplaycli.actions.model.TracksPatchModel
 import com.github.vacxe.googleplaycli.actions.model.TracksUpdateModel
@@ -10,21 +10,21 @@ import com.google.api.services.androidpublisher.model.TrackRelease
 import com.google.api.services.androidpublisher.model.TracksListResponse
 
 interface Tracks : BaseAction {
-    fun tracksList(model: DefaultModel): TracksListResponse {
+    fun tracksList(model: EditModel): TracksListResponse {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.tracks().list(model.packageName, insert.id).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.tracks().list(model.packageName, editId).execute()
     }
 
     fun tracksGet(model: TracksGetModel): Track {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
-        return edits.tracks().get(model.packageName, insert.id, model.track).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
+        return edits.tracks().get(model.packageName, editId, model.track).execute()
     }
 
     fun tracksPatch(model: TracksPatchModel): Track {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
+        val editId = model.editId ?: edits.insert(model.packageName, null).execute().id
 
         val track = Track().setReleases(
                 listOf(TrackRelease().apply {
@@ -32,18 +32,18 @@ interface Tracks : BaseAction {
                     userFraction = model.userFraction
                 })
         )
-        return edits.tracks().patch(model.packageName, insert.id, model.track, track).execute()
+        return edits.tracks().patch(model.packageName, editId, model.track, track).execute()
     }
 
     fun tracksUpdate(model: TracksUpdateModel): Track {
         val edits: AndroidPublisher.Edits = androidPublisher.edits()
-        val insert = edits.insert(model.packageName, null).execute()
 
-        val track = Track().setReleases(
-                listOf(TrackRelease().apply {
-                    versionCodes = mutableListOf(model.apkVersionCode.toLong())
-                })
-        )
-        return edits.tracks().update(model.packageName, insert.id, model.track, track).execute()
+        val release = TrackRelease()
+                .setVersionCodes(listOf(model.apkVersionCode.toLong()))
+                .setStatus("completed")
+
+        val track = Track().setReleases(listOf(release))
+
+        return edits.tracks().update(model.packageName, model.editId, model.track, track).execute()
     }
 }

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ApksUploadModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ApksUploadModel.kt
@@ -2,4 +2,4 @@ package com.github.vacxe.googleplaycli.actions.model
 
 import java.io.File
 
-data class ApksUploadModel(val packageName: String, val apk: File)
+data class ApksUploadModel(val packageName: String, val editId: String?, val apk: File)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/BundlesUploadModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/BundlesUploadModel.kt
@@ -2,4 +2,7 @@ package com.github.vacxe.googleplaycli.actions.model
 
 import java.io.File
 
-data class BundlesUploadModel(val packageName: String, val bundle: File, val ackBundleInstallationWarning: Boolean)
+data class BundlesUploadModel(val packageName: String,
+                              val editId: String?,
+                              val bundle: File,
+                              val ackBundleInstallationWarning: Boolean)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/DeobfuscationfilesUploadModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/DeobfuscationfilesUploadModel.kt
@@ -2,4 +2,8 @@ package com.github.vacxe.googleplaycli.actions.model
 
 import java.io.File
 
-data class DeobfuscationfilesUploadModel(val packageName: String, val apkVersionCode: Int, val deobfuscation: File, val deobfuscationFileType: String)
+data class DeobfuscationfilesUploadModel(val packageName: String,
+                                         val editId: String?,
+                                         val apkVersionCode: Int,
+                                         val deobfuscation: File,
+                                         val deobfuscationFileType: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/DetailsPatchModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/DetailsPatchModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class DetailsPatchModel(val packageName: String,
+                        val editId: String?,
                         val contactEmail: String?,
                         val contactPhone: String?,
                         val contactWebsite: String?,

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/DetailsUpdateModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/DetailsUpdateModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class DetailsUpdateModel(val packageName: String,
+                         val editId: String?,
                          val contactEmail: String?,
                          val contactPhone: String?,
                          val contactWebsite: String?,

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/EditModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/EditModel.kt
@@ -1,0 +1,3 @@
+package com.github.vacxe.googleplaycli.actions.model
+
+class EditModel(val packageName: String, val editId: String?)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ExpansionFilesGetModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ExpansionFilesGetModel.kt
@@ -1,5 +1,6 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class ExpansionFilesGetModel(val packageName: String,
+                             val editId: String?,
                              val apkVersionCode: Int,
                              val expansionFileType: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ExpansionFilesPatchModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ExpansionFilesPatchModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class ExpansionFilesPatchModel(val packageName: String,
+                               val editId: String?,
                                val apkVersionCode: Int,
                                val expansionFileType: String,
                                val referencesVersion: Int?,

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ExpansionFilesUpdateModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ExpansionFilesUpdateModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class ExpansionFilesUpdateModel(val packageName: String,
+                                val editId: String?,
                                 val apkVersionCode: Int,
                                 val expansionFileType: String,
                                 val referencesVersion: Int,

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ExpansionFilesUploadModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ExpansionFilesUploadModel.kt
@@ -3,6 +3,7 @@ package com.github.vacxe.googleplaycli.actions.model
 import java.io.File
 
 class ExpansionFilesUploadModel(val packageName: String,
+                                val editId: String?,
                                 val apkVersionCode: Int,
                                 val expansionFileType: String,
                                 val expansionFile: File)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ImagesDeleteAllModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ImagesDeleteAllModel.kt
@@ -1,5 +1,6 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 data class ImagesDeleteAllModel(val packageName: String,
+                                val editId: String?,
                                 val imageType: String,
                                 val language: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ImagesDeleteModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ImagesDeleteModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 data class ImagesDeleteModel(val packageName: String,
+                             val editId: String?,
                              val imageType: String,
                              val language: String,
                              val imageId: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ImagesListModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ImagesListModel.kt
@@ -1,5 +1,6 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 data class ImagesListModel(val packageName: String,
+                           val editId: String?,
                            val imageType: String,
                            val language: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ImagesUploadModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ImagesUploadModel.kt
@@ -3,6 +3,7 @@ package com.github.vacxe.googleplaycli.actions.model
 import java.io.File
 
 data class ImagesUploadModel(val packageName: String,
+                             val editId: String?,
                              val imageType: String,
                              val language: String,
                              val image: File)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ListingsDeleteModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ListingsDeleteModel.kt
@@ -1,4 +1,5 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class ListingsDeleteModel(val packageName: String,
+                          val editId: String?,
                           val language: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ListingsGetModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ListingsGetModel.kt
@@ -1,4 +1,5 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class ListingsGetModel(val packageName: String,
+                       val editId: String?,
                        val language: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ListingsPatchModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ListingsPatchModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class ListingsPatchModel(val packageName: String,
+                         val editId: String?,
                          val language: String?,
                          val fullDescription: String?,
                          val shortDescription: String?,

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ListingsUpdateModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ListingsUpdateModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class ListingsUpdateModel(val packageName: String,
+                          val editId: String?,
                           val language: String,
                           val fullDescription: String,
                           val shortDescription: String,

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/OrdersRefundModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/OrdersRefundModel.kt
@@ -1,5 +1,6 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 data class OrdersRefundModel(val packageName: String,
+                             val editId: String?,
                              val orderId: String,
                              val revoke: Boolean)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ReviewsGetModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ReviewsGetModel.kt
@@ -1,5 +1,6 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 data class ReviewsGetModel(val packageName: String,
+                           val editId: String?,
                            val reviewId: String,
                            val translationLanguage: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ReviewsListModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ReviewsListModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 data class ReviewsListModel(val packageName: String,
+                            val editId: String?,
                             val maxResults: Long,
                             val startIndex: Long,
                             val token: String,

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ReviewsReplyModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/ReviewsReplyModel.kt
@@ -1,5 +1,6 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 data class ReviewsReplyModel(val packageName: String,
+                             val editId: String?,
                              val reviewId: String,
                              val replyText: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TestersGetModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TestersGetModel.kt
@@ -1,4 +1,5 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class TestersGetModel(val packageName: String,
+                      val editId: String?,
                       val track: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TestersPatchModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TestersPatchModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class TestersPatchModel(val packageName: String,
+                        val editId: String?,
                         val track: String,
                         val googleGroups: List<String>?,
                         val googlePlusCommunities: List<String>?)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TestersUpdateModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TestersUpdateModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 class TestersUpdateModel(val packageName: String,
+                         val editId: String?,
                          val track: String,
                          val googleGroups: List<String>,
                          val googlePlusCommunities: List<String>)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TracksGetModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TracksGetModel.kt
@@ -1,4 +1,5 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 data class TracksGetModel(val packageName: String,
+                          val editId: String?,
                           val track: String)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TracksPatchModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TracksPatchModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 data class TracksPatchModel(val packageName: String,
+                            val editId: String?,
                             val track: String,
                             val apkVersionCode: Int,
                             val userFraction: Double)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TracksUpdateModel.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/actions/model/TracksUpdateModel.kt
@@ -1,6 +1,7 @@
 package com.github.vacxe.googleplaycli.actions.model
 
 data class TracksUpdateModel(val packageName: String,
+                             val editId: String?,
                              val track: String,
                              val apkVersionCode: Int,
                              val userFraction: Double)

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/core/EditCommand.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/core/EditCommand.kt
@@ -1,0 +1,7 @@
+package com.github.vacxe.googleplaycli.core
+
+import com.github.ajalt.clikt.parameters.options.option
+
+abstract class EditCommand(name: String, actionDescription: String = "") : BaseCommand(name, actionDescription) {
+    val editId: String? by option("--edit-id", "-id", help = "Edit id")
+}

--- a/src/main/kotlin/com/github/vacxe/googleplaycli/dsl/dsl.kt
+++ b/src/main/kotlin/com/github/vacxe/googleplaycli/dsl/dsl.kt
@@ -2,22 +2,12 @@ package com.github.vacxe.googleplaycli.dsl
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
-import com.github.vacxe.googleplaycli.PlayStoreApi
-import com.github.vacxe.googleplaycli.core.BaseCommand
 import com.github.vacxe.googleplaycli.core.MetaCommand
 
 fun cmd(name: String, configurationBlock: MetaCommand.() -> Unit): MetaCommand = MetaCommand(name).apply(configurationBlock)
 
 fun MetaCommand.subcmd(name: String, configurationBlock: MetaCommand.() -> Unit) {
     subcommands(cmd(name, configurationBlock))
-}
-
-fun MetaCommand.baseCmd(name: String, description: String = "", block: BaseCommand.(PlayStoreApi) -> Any) {
-    subcommands(
-            object : BaseCommand(name = name, actionDescription = description) {
-                override fun run(api: PlayStoreApi) = block(api)
-            }
-    )
 }
 
 fun MetaCommand.addCmd(block: () -> CliktCommand) {


### PR DESCRIPTION
Purpose:
For example we want to upload APK to `internal` testing channel. We should do it in the same transaction (*edit id*). Unfortunately we can't upload it to any channel without this chain. Also any transaction should be committed. 

```
edit create --config service_account.json --package-name com.any.package
apk upload --config service_account.json --package-name com.any.package --edit-id <my-transaction-id> --apk app-release.apk
tracks update --config service_account.json --package-name com.any.package --edit-id <my-transaction-id> --track "internal" --apk-version-code <my-version-code>
edit validate --config service_account.json --package-name com.any.package --edit-id <my-transaction-id>
edit commit --config service_account.json --package-name com.any.package --edit-id <my-transaction-id>
```
