### PR TITLE
Switch to a JRE 23 base image on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:23-jre-alpine AS builder
+FROM eclipse-temurin:25-jre-alpine AS builder
 
 ARG PLAY_CLI_VERSION
 
@@ -10,7 +10,7 @@ RUN wget -q "https://github.com/Vacxe/google-play-cli-kt/releases/download/${PLA
     tar -xvf "google-play-cli.tar" -C /opt && \
     rm "google-play-cli.tar"
 
-FROM eclipse-temurin:23-jre-alpine AS app
+FROM eclipse-temurin:25-jre-alpine AS app
 
 # copy the cli binaries
 COPY --from=builder /opt/google-play-cli /opt/google-play-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jre-alpine AS builder
+FROM eclipse-temurin:23-jre-alpine AS builder
 
 ARG PLAY_CLI_VERSION
 
@@ -10,7 +10,7 @@ RUN wget -q "https://github.com/Vacxe/google-play-cli-kt/releases/download/${PLA
     tar -xvf "google-play-cli.tar" -C /opt && \
     rm "google-play-cli.tar"
 
-FROM eclipse-temurin:25-jre-alpine AS app
+FROM eclipse-temurin:23-jre-alpine AS app
 
 # copy the cli binaries
 COPY --from=builder /opt/google-play-cli /opt/google-play-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,24 @@
-FROM eclipse-temurin:23-jdk
+FROM eclipse-temurin:23-jre-alpine AS builder
 
 ARG PLAY_CLI_VERSION
 
-RUN apt-get update
-RUN apt-get install -y wget unzip jq
+RUN apk update && \
+    apk add wget
 
 # Install released Version from artefacts
-RUN wget -q "https://github.com/Vacxe/google-play-cli-kt/releases/download/$PLAY_CLI_VERSION/google-play-cli.tar" && \
-    tar -xvf "google-play-cli.tar" -C /usr/local &&  \
+RUN wget -q "https://github.com/Vacxe/google-play-cli-kt/releases/download/${PLAY_CLI_VERSION}/google-play-cli.tar" && \
+    tar -xvf "google-play-cli.tar" -C /opt && \
     rm "google-play-cli.tar"
 
-ENV PATH="${PATH}:/usr/local/google-play-cli/bin/"
+FROM eclipse-temurin:23-jre-alpine AS app
 
-RUN echo "CLI version:" && google-play-cli version
+# copy the cli binaries
+COPY --from=builder /opt/google-play-cli /opt/google-play-cli
+
+# soft link the cli to /usr/local/bin and check it works ok
+RUN ln -s /opt/google-play-cli/bin/google-play-cli /usr/local/bin/google-play-cli && \
+    echo "CLI version:" && google-play-cli version
+
+# set the entrypoint to the cli and default args to `--help`
+ENTRYPOINT [ "google-play-cli" ]
+CMD [ "--help" ]


### PR DESCRIPTION
Great project! I plan to make use of it from my GH workflows. This PR contains a few quality of life changes, so nothing critical and no new features.

I've made a number of changes to the Dockerfile as follows:
- Use `eclipse-temurin:23-jre-alpine` as the base image
- Added a multi-stage build so `wget` and any other build-time tools don't end up on the final image
- Extracted the tar to `/opt` rather than `/usr/local` and soft linked `google-play-cli` into `/usr/local/bin` which is on the path by default
- Set `google-play-cli` as the `entrypoint`

### Advantages
- the Alpine JRE image is much smaller than the Noble JDK image and has no critical vulnerabilities
- build time tools don't appear in the final image since they can introduce unwanted vulnerabilities
- the final image is 236MB compared to 509MB
- the container directly accepts the app command line parameters, this is more natural than updating the path and requiring the user to supply the app name when invoking the container

For example when invoking this version you'd use `docker run -ti --rm vacxe/google-play-cli` to see help rather than `docker run -ti --rm vacxe/google-play-cli google-play-cli --help`.

You can see the same approach to Dockerfile structure in the `anchore/grype` image which is a great free image scanning tool, for example: https://github.com/anchore/grype/blob/9d54499415ad6f34426ce82082fa205a2e6bc45a/Dockerfile#L29 shows the entrypoint behaviour.